### PR TITLE
Let Vec handle alignment using generics.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,28 +3,29 @@
 
 //! # memalloc
 //!
-//! Memory allocation in stable rust, providing a similar interface to `std::rt::heap`,
-//! notably these functions align everything according to the alignment of `u8`, rather
-//! than using a user-provided alignment.
+//! Memory allocation in stable rust, using generics and the implementation of
+//! Vec to handle the actual memory management including alignment.
 //!
-//! Additionally, they do not allow for handling allocation failure, and will simply
+//! This library do not allow for handling allocation failure, and will simply
 //! abort the process on OOM. Unfortunately, this limitation is unavoidable if we want
 //! to use only stable APIs.
-//!
 
 use std::mem;
 
-/// Returns a pointer to `size` bytes of memory aligned to `mem::align_of::<u8>()`.
+/// Returns a pointer to `size` number of elements of type T, or in other
+/// words `size` * mem::size_of::<T>() bytes. Memory is aligned by the
+/// implementation of Vec<T>.
 ///
 /// On failure, aborts the process.
 ///
 /// Behavior is undefined if the requested size is 0.
 #[inline]
-pub unsafe fn allocate(size: usize) -> *mut u8 {
+pub unsafe fn typed_alloc<T>(size: usize) -> *mut T {
     ptr_from_vec(Vec::with_capacity(size))
 }
 
-/// Resizes the allocation referenced by `ptr` to `new_size` bytes.
+/// Resizes the allocation referenced by `ptr` to `new_size` number of elements
+/// of type T.
 ///
 /// On failure, aborts the process.
 ///
@@ -35,7 +36,7 @@ pub unsafe fn allocate(size: usize) -> *mut u8 {
 ///
 /// The `old_size` parameter is the size used to create the allocation
 /// referenced by `ptr`, or the `new_size` passed to previous reallocations.
-pub unsafe fn reallocate(ptr: *mut u8, old_size: usize, new_size: usize) -> *mut u8 {
+pub unsafe fn typed_realloc<T>(ptr: *mut T, old_size: usize, new_size: usize) -> *mut T {
     if old_size > new_size {
         let mut buf = Vec::from_raw_parts(ptr, new_size, old_size);
         buf.shrink_to_fit();
@@ -60,19 +61,23 @@ pub unsafe fn reallocate(ptr: *mut u8, old_size: usize, new_size: usize) -> *mut
 /// The `old_size` parameter is the size used to create the allocation
 /// referenced by `ptr`, or the `new_size` passed to the last reallocation.
 #[inline]
-pub unsafe fn deallocate(ptr: *mut u8, old_size: usize) {
+pub unsafe fn typed_dealloc<T>(ptr: *mut T, old_size: usize) {
     Vec::from_raw_parts(ptr, 0, old_size);
 }
 
-/// A token empty allocation which cannot be read from or written to,
-/// but which can be used as a placeholder when a 0-sized allocation is
-/// required.
-pub fn empty() -> *mut u8 {
-    1 as *mut u8
-}
+// Investigate later, is this safe? Looks like creating a pointer to address
+// 1, or returning a pointer to the stack?
+// Original below:
+//
+// A token empty allocation which cannot be read from or written to,
+// but which can be used as a placeholder when a 0-sized allocation is
+// required.
+//pub fn empty() -> *mut u8 {
+//  1 as *mut u8
+//}
 
 #[inline]
-fn ptr_from_vec(mut buf: Vec<u8>) -> *mut u8 {
+fn ptr_from_vec<T>(mut buf: Vec<T>) -> *mut T {
     let ptr = buf.as_mut_ptr();
     mem::forget(buf);
 
@@ -82,17 +87,20 @@ fn ptr_from_vec(mut buf: Vec<u8>) -> *mut u8 {
 #[cfg(test)]
 mod tests {
     use std::ptr;
-    use {allocate, reallocate, deallocate, empty};
+    use {typed_alloc, typed_realloc, typed_dealloc};
 
+    /* Suspicious, TODO: Investigate later.
+    //use empty;
     #[test]
     fn test_empty() {
-        let ptr = empty();
+        let ptr: *mut u8 = empty();
         assert!(ptr != ptr::null_mut());
     }
+    */
 
     #[test]
     fn test_allocate() {
-        let buffer = unsafe { allocate(8) };
+        let buffer = unsafe { typed_alloc(8) };
 
         assert!(buffer != ptr::null_mut());
 
@@ -110,10 +118,12 @@ mod tests {
             assert_eq!(ptr::read(buffer.offset(7)), 6);
         };
 
-        unsafe { deallocate(buffer, 8); }
+        unsafe {
+            typed_dealloc(buffer, 8);
+        }
 
         // Try a large buffer
-        let buffer = unsafe { allocate(1024 * 1024) };
+        let buffer = unsafe { typed_alloc(1024 * 1024) };
         assert!(buffer != ptr::null_mut());
 
         unsafe {
@@ -121,15 +131,17 @@ mod tests {
             assert_eq!(ptr::read(buffer.offset(1024 * 1024 - 1)), 12);
         };
 
-        unsafe { deallocate(buffer, 1024 * 1024); }
+        unsafe {
+            typed_dealloc(buffer, 1024 * 1024);
+        }
     }
 
     #[test]
     fn test_reallocate() {
-        let mut buffer = unsafe { allocate(8) };
+        let mut buffer = unsafe { typed_alloc(8) };
         assert!(buffer != ptr::null_mut());
 
-        buffer = unsafe { reallocate(buffer, 8, 16) };
+        buffer = unsafe { typed_realloc(buffer, 8, 16) };
         assert!(buffer != ptr::null_mut());
 
         unsafe {
@@ -141,9 +153,11 @@ mod tests {
         };
 
         // Allocate so in-place fails.
-        unsafe { allocate(128) };
+        unsafe {
+            let _: *mut u8 = typed_alloc(128);
+        };
 
-        buffer = unsafe { reallocate(buffer, 16, 32) };
+        buffer = unsafe { typed_realloc(buffer, 16, 32) };
         assert!(buffer != ptr::null_mut());
 
         unsafe {
@@ -155,4 +169,3 @@ mod tests {
         };
     }
 }
-


### PR DESCRIPTION
I found this library while searching for alternatives to unstable rust (porting old unstable Rust code to work in latest stable). I also found this: https://www.reddit.com/r/rust/comments/5weidf/no_stable_mallocfree_in_rust_stdlib/

In that reddit thread there were some discussion on alignment issues, so this is an attempt to solve that with minimal changes to this library. Any feedback welcome!

EDIT: I'm uncertain about the usefulness of this PR, but maybe it can start some discussion. I'm not sure the usage of the changed API would be any less complex than the old one. Feel free to close! 